### PR TITLE
better unicode: false options (utf8 escaped chars)

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,11 +3,11 @@ module.exports = function archy (obj, prefix, opts) {
     if (!opts) opts = {};
     var chr = function (s) {
         var chars = {
-            '│' : '|',
-            '└' : '`',
-            '├' : '+',
-            '─' : '-',
-            '┬' : '-'
+            '│' : '\u2502',
+            '└' : '\u2514',
+            '├' : '\u251C',
+            '─' : '\u2500',
+            '┬' : '\u252C'
         };
         return opts.unicode === false ? chars[s] : s;
     };


### PR DESCRIPTION
Hey @substack , I'm using Archy for a project of mine and want a clearer in-browser look.

here's what my proposal looks like : 

![](https://i.imgur.com/Dam5KBq.png)

I trwaled utf8 and picked characters from [here](http://www.utf8-chartable.de/unicode-utf8-table.pl?start=9472) 